### PR TITLE
Added ability to send discrete metrics to DataDog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build clean
+
+build:
+	env GOOS=linux go build -ldflags="-s -w" -o bin/passenger-datadog-monitor *.go
+
+clean:
+	rm -rf ./bin

--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func processPerThreadRequests(passengerDetails *passengerStatus) map[int]float64
 	var processPerThreadProcessed = make(map[int]float64)
 	p := passengerDetails.Processes
 	for _, processedReq := range p {
-		processPerThreadProcessed[processedReq.PID]=floatMyInt(processedReq.Processed)
+		processPerThreadProcessed[processedReq.PID] = floatMyInt(processedReq.Processed)
 	}
 	return processPerThreadProcessed
 }
@@ -245,31 +245,47 @@ func chartDiscreteMetrics(passengerDetails *passengerStatus, DogStatsD *godspeed
 	threadMemoryUsages := processPerThreadMemoryUsage(passengerDetails)
 	threadIdletimes := processPerThreadIdleTime(passengerDetails)
 	threadProcessedCounts := processPerThreadRequests(passengerDetails)
-	if printOutput {fmt.Println("|====Process Thread Counts====|")}
+	if printOutput {
+		fmt.Println("|====Process Thread Counts====|")
+	}
 	for pid, count := range threadCountPerProcess {
-		if printOutput{fmt.Printf("PID: %d  Running: %0.2f threads\n",pid,count)}
-		tag := fmt.Sprintf("pid:%d",pid)
+		if printOutput {
+			fmt.Printf("PID: %d  Running: %0.2f threads\n", pid, count)
+		}
+		tag := fmt.Sprintf("pid:%d", pid)
 		_ = DogStatsD.Gauge("passenger.process.threads", count, []string{tag})
 	}
 
-	if printOutput {fmt.Println("|====Process Memory Usage====|")}
+	if printOutput {
+		fmt.Println("|====Process Memory Usage====|")
+	}
 	for pid, memUse := range threadMemoryUsages {
-		if printOutput{fmt.Printf("PID: %d Memory_Used: %0.2f MB\n",pid,memUse)}
-		tag := fmt.Sprintf("pid:%d",pid)
+		if printOutput {
+			fmt.Printf("PID: %d Memory_Used: %0.2f MB\n", pid, memUse)
+		}
+		tag := fmt.Sprintf("pid:%d", pid)
 		_ = DogStatsD.Gauge("passenger.process.memory", memUse, []string{tag})
 	}
 
-	if printOutput {fmt.Println("|====Process Idle Times====|")}
+	if printOutput {
+		fmt.Println("|====Process Idle Times====|")
+	}
 	for pid, seconds := range threadIdletimes {
-		if printOutput{fmt.Printf("PID: %d Idle: %d Seconds\n",pid,int(seconds))}
-		tag := fmt.Sprintf("pid:%d",pid)
+		if printOutput {
+			fmt.Printf("PID: %d Idle: %d Seconds\n", pid, int(seconds))
+		}
+		tag := fmt.Sprintf("pid:%d", pid)
 		_ = DogStatsD.Gauge("passenger.process.last_used", seconds, []string{tag})
 	}
 
-	if printOutput {fmt.Println("|====Process Requests Handled====|")}
+	if printOutput {
+		fmt.Println("|====Process Requests Handled====|")
+	}
 	for pid, count := range threadProcessedCounts {
-		if printOutput{fmt.Printf("PID: %d Processed: %d Requests\n",pid,int(count))}
-		tag := fmt.Sprintf("pid:%d",pid)
+		if printOutput {
+			fmt.Printf("PID: %d Processed: %d Requests\n", pid, int(count))
+		}
+		tag := fmt.Sprintf("pid:%d", pid)
 		_ = DogStatsD.Gauge("passenger.process.request_processed", count, []string{tag})
 	}
 }
@@ -301,7 +317,7 @@ func main() {
 			chartPendingRequest(&PassengerStatusData, DogStatsD)
 			chartPoolUse(&PassengerStatusData, DogStatsD)
 			chartProcessUptime(&PassengerStatusData, DogStatsD)
-			chartDiscreteMetrics(&PassengerStatusData,DogStatsD)
+			chartDiscreteMetrics(&PassengerStatusData, DogStatsD)
 			DogStatsD.Conn.Close()
 		}
 		time.Sleep(10 * time.Second)

--- a/main.go
+++ b/main.go
@@ -12,28 +12,31 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 )
 
-var print bool
+var printOutput bool
 
 type passengerStatus struct {
 	XMLName      xml.Name  `xml:"info"`
 	ProcessCount int       `xml:"process_count"`
 	PoolMax      int       `xml:"max"`
 	PoolCurrent  int       `xml:"capacity_used"`
-	QueuedCount  []int       `xml:"supergroups>supergroup>group>get_wait_list_size"`
+	QueuedCount  []int     `xml:"supergroups>supergroup>group>get_wait_list_size"`
 	Processes    []process `xml:"supergroups>supergroup>group>processes>process"`
 }
 
 type process struct {
-	CurrentSessions int `xml:"sessions"`
-	Processed       int `xml:"processed"`
-	SpawnTime       int `xml:"spawn_end_time"`
-	CPU             int `xml:"cpu"`
-	Memory          int `xml:"real_memory"`
+	CurrentSessions int   `xml:"sessions"`
+	Processed       int   `xml:"processed"`
+	SpawnTime       int64 `xml:"spawn_end_time"`
+	CPU             int   `xml:"cpu"`
+	Memory          int   `xml:"real_memory"`
+	PID             int   `xml:"pid"`
+	LastUsed        int64 `xml:"last_used"`
 }
-
 
 //Stats is used to store stats
 type Stats struct {
@@ -44,7 +47,7 @@ type Stats struct {
 	sum int
 }
 
-func summerizeStats(statsArray *[]int) Stats {
+func summarizeStats(statsArray *[]int) Stats {
 	var processedStats Stats
 	sum, count := 0, len(*statsArray)
 	sort.Sort(sort.IntSlice(*statsArray))
@@ -70,6 +73,7 @@ func retrievePassengerStats() (io.Reader, error) {
 	}
 	return bytes.NewReader(out), nil
 }
+
 func parsePassengerXML(xmlData *io.Reader) (passengerStatus, error) {
 	var ParsedPassengerXML passengerStatus
 	dec := xml.NewDecoder(*xmlData)
@@ -81,8 +85,23 @@ func parsePassengerXML(xmlData *io.Reader) (passengerStatus, error) {
 	return ParsedPassengerXML, nil
 }
 
-func floatMyInt(value int) float64{
-    return float64(value)
+func floatMyInt(value int) float64 {
+	return float64(value)
+}
+
+func getProcessThreadCount(pid int) (int, error) {
+	//ps -o nlwp --no-heading to get number of lightweight peoceses for given pid
+	out, err := exec.Command("ps", "--no-header", "-o", "nlwp", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, fmt.Errorf("encountered error issuing command to retrieve"+
+			" thread count from pid %d, error: %s", pid, err)
+	}
+	countString := strings.TrimSpace(string(out))
+	count, err := strconv.Atoi(countString)
+	if err != nil {
+		return 0, fmt.Errorf("encountered error parsing thread count from command return value, erro: %s", err)
+	}
+	return count, nil
 }
 
 func processed(passengerDetails *passengerStatus) Stats {
@@ -91,16 +110,21 @@ func processed(passengerDetails *passengerStatus) Stats {
 	for _, processStats := range processes {
 		processed = append(processed, processStats.Processed)
 	}
-	return summerizeStats(&processed)
+	return summarizeStats(&processed)
 }
+
 func memory(passengerDetails *passengerStatus) Stats {
 	var memory []int
 	processes := passengerDetails.Processes
 	for _, processStats := range processes {
 		memory = append(memory, processStats.Memory)
 	}
-	return summerizeStats(&memory)
+	return summarizeStats(&memory)
 }
+
+// Timestamps from Passenger Status are returned in microseconds (1/1,000,000 second) units
+// Golang unix time function only accepts seconds or nano (1/1,000,000,000) seconds
+// multiplying by 1000 to get nano from micro
 func processUptime(passengerDetails *passengerStatus) Stats {
 
 	var upTimes []int
@@ -110,100 +134,176 @@ func processUptime(passengerDetails *passengerStatus) Stats {
 		uptime := time.Since(SpawnedNano)
 		upTimes = append(upTimes, int(uptime.Minutes()))
 	}
-	return summerizeStats(&upTimes)
+	return summarizeStats(&upTimes)
 }
 
 func chartPendingRequest(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
-    var totalQueued int
-    for _,queued := range passengerDetails.QueuedCount {
-        totalQueued += queued
-    }
-    if print {
-		fmt.Println("|=====Queue Depth====|")
-		fmt.Println("Queue Depth", totalQueued)
+	var totalQueued int
+	for _, queued := range passengerDetails.QueuedCount {
+		totalQueued += queued
 	}
-    DogStatsD.Gauge("passenger.queue.depth", floatMyInt(totalQueued),nil)
+	if printOutput {
+		fmt.Printf("\n|=====Queue Depth====|\n Queue Depth %d", totalQueued)
+	}
+	_ = DogStatsD.Gauge("passenger.queue.depth", floatMyInt(totalQueued), nil)
 }
+
 func chartPoolUse(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
-	if print {
-		fmt.Println("|=====Pool Usage====|")
-		fmt.Println("Used Pool", passengerDetails.ProcessCount)
-		fmt.Println("Max Pool", passengerDetails.PoolMax)
+	if printOutput {
+		fmt.Printf("\n|=====Pool Usage====|\n Used Pool %d\n Max Pool %d", passengerDetails.ProcessCount, passengerDetails.PoolMax)
 	}
-        DogStatsD.Gauge("passenger.pool.used", floatMyInt(passengerDetails.ProcessCount),nil)
-        DogStatsD.Gauge("passenger.pool.max", floatMyInt(passengerDetails.PoolMax),nil)
+	_ = DogStatsD.Gauge("passenger.pool.used", floatMyInt(passengerDetails.ProcessCount), nil)
+	_ = DogStatsD.Gauge("passenger.pool.max", floatMyInt(passengerDetails.PoolMax), nil)
 }
+
 func chartProcessed(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
 	stats := processed(passengerDetails)
-	if print {
-		fmt.Println("|=====Processed====|")
-		fmt.Println("Total processed", stats.sum)   //sum processed by threads
-		fmt.Println("Average processed", stats.avg) //average processed by threads
-		fmt.Println("Minimum processed", stats.min)
-		fmt.Println("Maximum processed", stats.max)
+	if printOutput {
+		fmt.Printf("\n|=====Processed====|\n Total processsed %d\n Average processed %d\n"+
+			" Minimum processed %d\n Maximum processed %d", stats.sum, stats.avg, stats.min, stats.max)
 	}
-    DogStatsD.Gauge("passenger.processed.total",floatMyInt(stats.sum),nil)
-    DogStatsD.Gauge("passenger.processed.avg",floatMyInt(stats.avg),nil)
-    DogStatsD.Gauge("passenger.processed.min",floatMyInt(stats.min),nil)
-    DogStatsD.Gauge("passenger.processed.max",floatMyInt(stats.max),nil)
+	_ = DogStatsD.Gauge("passenger.processed.total", floatMyInt(stats.sum), nil)
+	_ = DogStatsD.Gauge("passenger.processed.avg", floatMyInt(stats.avg), nil)
+	_ = DogStatsD.Gauge("passenger.processed.min", floatMyInt(stats.min), nil)
+	_ = DogStatsD.Gauge("passenger.processed.max", floatMyInt(stats.max), nil)
 
 }
+
 func chartMemory(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
 	stats := memory(passengerDetails)
-	if print {
-		fmt.Println("|=====Memory====|")
-		fmt.Println("Total memory", stats.sum/1024)
-		fmt.Println("Average memory", stats.avg/1024)
-		fmt.Println("Minimum memory", stats.min/1024)
-		fmt.Println("Maximum memory", stats.max/1024)
+	if printOutput {
+		fmt.Printf("\n|=====Memory====|\n Total memory %d\n Average memory %d\n"+
+			" Minimum memory %d\n Maximum memory %d", stats.sum/1024, stats.avg/1024, stats.min/1024, stats.max/1024)
 	}
-    DogStatsD.Gauge("passenger.memory.total",floatMyInt(stats.sum/1024),nil)
-    DogStatsD.Gauge("passenger.memory.avg",floatMyInt(stats.avg/1024),nil)
-    DogStatsD.Gauge("passenger.memory.min",floatMyInt(stats.min/1024),nil)
-    DogStatsD.Gauge("passenger.memory.max",floatMyInt(stats.max/1024),nil)
+	_ = DogStatsD.Gauge("passenger.memory.total", floatMyInt(stats.sum/1024), nil)
+	_ = DogStatsD.Gauge("passenger.memory.avg", floatMyInt(stats.avg/1024), nil)
+	_ = DogStatsD.Gauge("passenger.memory.min", floatMyInt(stats.min/1024), nil)
+	_ = DogStatsD.Gauge("passenger.memory.max", floatMyInt(stats.max/1024), nil)
 }
+
 func chartProcessUptime(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
 	stats := processUptime(passengerDetails)
-	if print {
-		fmt.Println("|=====Process uptime====|")
-		fmt.Println("Average uptime", stats.avg, "min")
-		fmt.Println("Minimum uptime", stats.min, "min")
-		fmt.Println("Maximum uptime", stats.max, "min")
+	if printOutput {
+		fmt.Printf("\n|=====Process uptime====|\n Average uptime %d min\n"+
+			" Minimum uptime %d min\n Maximum uptime %d min\n", stats.avg, stats.min, stats.max)
 	}
-    DogStatsD.Gauge("passenger.uptime.avg",floatMyInt(stats.avg),nil)
-    DogStatsD.Gauge("passenger.uptime.min",floatMyInt(stats.min),nil)
-    DogStatsD.Gauge("passenger.uptime.max",floatMyInt(stats.max),nil)
+	_ = DogStatsD.Gauge("passenger.uptime.avg", floatMyInt(stats.avg), nil)
+	_ = DogStatsD.Gauge("passenger.uptime.min", floatMyInt(stats.min), nil)
+	_ = DogStatsD.Gauge("passenger.uptime.max", floatMyInt(stats.max), nil)
+}
+
+//go through each process in the tree and get the per process thread count and per process last used time
+func processSystemThreadUsage(passengerDetails *passengerStatus) map[int]float64 {
+	var processThreads = make(map[int]float64)
+	p := passengerDetails.Processes
+	for _, processDetails := range p {
+		//take the PID and do a thread count lookup using PS
+		tc, err := getProcessThreadCount(processDetails.PID)
+		if err != nil {
+			_ = err
+			//log.Printf("encountered error getting thread count %s", err)
+		}
+		processThreads[processDetails.PID] = floatMyInt(tc)
+	}
+	return processThreads
+}
+
+func processPerThreadMemoryUsage(passengerDetails *passengerStatus) map[int]float64 {
+	var processMemory = make(map[int]float64)
+	p := passengerDetails.Processes
+	for _, processDetails := range p {
+		processMemory[processDetails.PID] = floatMyInt(processDetails.Memory) / 1024
+	}
+	return processMemory
+}
+
+// Timestamps from Passenger Status are returned in microseconds units
+// Golang unix time function only accepts seconds or nano seconds
+// multiplying by 1000 to get nano from micro
+func processPerThreadIdleTime(passengerDetails *passengerStatus) map[int]float64 {
+	var processIdleTimes = make(map[int]float64)
+	p := passengerDetails.Processes
+	for _, processDetails := range p {
+		LastUsedTime := time.Unix(0, int64(processDetails.LastUsed*1000))
+		lastUsedSeconds := time.Since(LastUsedTime).Seconds()
+		processIdleTimes[processDetails.PID] = lastUsedSeconds
+	}
+	return processIdleTimes
+}
+
+func processPerThreadRequests(passengerDetails *passengerStatus) map[int]float64 {
+	var processPerThreadProcessed = make(map[int]float64)
+	p := passengerDetails.Processes
+	for _, processedReq := range p {
+		processPerThreadProcessed[processedReq.PID]=floatMyInt(processedReq.Processed)
+	}
+	return processPerThreadProcessed
+}
+
+func chartDiscreteMetrics(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {
+	threadCountPerProcess := processSystemThreadUsage(passengerDetails)
+	threadMemoryUsages := processPerThreadMemoryUsage(passengerDetails)
+	threadIdletimes := processPerThreadIdleTime(passengerDetails)
+	threadProcessedCounts := processPerThreadRequests(passengerDetails)
+	if printOutput {fmt.Println("|====Process Thread Counts====|")}
+	for pid, count := range threadCountPerProcess {
+		if printOutput{fmt.Printf("PID: %d  Running: %0.2f threads\n",pid,count)}
+		tag := fmt.Sprintf("pid:%d",pid)
+		_ = DogStatsD.Gauge("passenger.process.threads", count, []string{tag})
+	}
+
+	if printOutput {fmt.Println("|====Process Memory Usage====|")}
+	for pid, memUse := range threadMemoryUsages {
+		if printOutput{fmt.Printf("PID: %d Memory_Used: %0.2f MB\n",pid,memUse)}
+		tag := fmt.Sprintf("pid:%d",pid)
+		_ = DogStatsD.Gauge("passenger.process.memory", memUse, []string{tag})
+	}
+
+	if printOutput {fmt.Println("|====Process Idle Times====|")}
+	for pid, seconds := range threadIdletimes {
+		if printOutput{fmt.Printf("PID: %d Idle: %d Seconds\n",pid,int(seconds))}
+		tag := fmt.Sprintf("pid:%d",pid)
+		_ = DogStatsD.Gauge("passenger.process.last_used", seconds, []string{tag})
+	}
+
+	if printOutput {fmt.Println("|====Process Requests Handled====|")}
+	for pid, count := range threadProcessedCounts {
+		if printOutput{fmt.Printf("PID: %d Processed: %d Requests\n",pid,int(count))}
+		tag := fmt.Sprintf("pid:%d",pid)
+		_ = DogStatsD.Gauge("passenger.process.request_processed", count, []string{tag})
+	}
 }
 
 func main() {
 	if len(os.Args[1:]) > 0 {
 		if os.Args[1] == "print" {
-			print = true
+			printOutput = true
 		}
 	}
-    for {
-        xmlData, err := retrievePassengerStats()
-        if err != nil {
-            log.Fatal("Error getting passenger data:", err)
-        }
-        PassengerStatusData, err := parsePassengerXML(&xmlData)
-        if err != nil {
-            log.Fatal("Error parsing passenger data:", err)
-        }
-        if PassengerStatusData.ProcessCount == 0 {
-            log.Println("Passenger has not yet started any threads, will try again next loop")
-        } else {
-        DogStatsD, err := godspeed.NewDefault()
-        if err != nil {
-            log.Fatal("Error establishing StatsD connection", err)
-        }
-        chartProcessed(&PassengerStatusData, DogStatsD)
-        chartMemory(&PassengerStatusData, DogStatsD)
-        chartPendingRequest(&PassengerStatusData, DogStatsD)
-        chartPoolUse(&PassengerStatusData, DogStatsD)
-        chartProcessUptime(&PassengerStatusData, DogStatsD)
-        DogStatsD.Conn.Close()
-        }
-        time.Sleep(10 * time.Second)
-    }
+	for {
+		xmlData, err := retrievePassengerStats()
+		if err != nil {
+			log.Fatal("Error getting passenger data:", err)
+		}
+		PassengerStatusData, err := parsePassengerXML(&xmlData)
+		if err != nil {
+			log.Fatal("Error parsing passenger data:", err)
+		}
+		if PassengerStatusData.ProcessCount == 0 {
+			log.Println("Passenger has not yet started any threads, will try again next loop")
+		} else {
+			DogStatsD, err := godspeed.NewDefault()
+			if err != nil {
+				log.Fatal("Error establishing StatsD connection", err)
+			}
+			chartProcessed(&PassengerStatusData, DogStatsD)
+			chartMemory(&PassengerStatusData, DogStatsD)
+			chartPendingRequest(&PassengerStatusData, DogStatsD)
+			chartPoolUse(&PassengerStatusData, DogStatsD)
+			chartProcessUptime(&PassengerStatusData, DogStatsD)
+			chartDiscreteMetrics(&PassengerStatusData,DogStatsD)
+			DogStatsD.Conn.Close()
+		}
+		time.Sleep(10 * time.Second)
+	}
 }


### PR DESCRIPTION
This changes allows metrics to be sent in none aggregated fashion. The following metrics are now sent per PID and tagged by accordingly.

- process memory usage
- OS thread count
- Requests processed
- Process Idle time 

New Keys are
- passenger.process.threads
- passenger.process.memory
- passenger.process.last_used
- passenger.process.request_processed