### PR TITLE
Add flags for host/port and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,59 @@
 # passenger-datadog-monitor
+
 Send health metrics from Phusion Passenger to DataDog using the StatsD interface on the server agent.
 
 ## Purpose
+
 Graph and track Passenger threads and possibly detect misbehaving threads before they become a problem.
 
 ## Tracked Metrics
-#### Aggregated
-* Processed requests: min,max,average,total
-* Memory usage: min,max,average,total
-* Thread uptime: min, max, average
-* Request queue depth
-* Threads in use *vs* Max thread configured & Threads used between runs
-#### Discrete
+
+### Aggregated
+
+- Processed requests: min,max,average,total
+- Memory usage: min,max,average,total
+- Thread uptime: min, max, average
+- Request queue depth
+- Threads in use _vs_ Max thread configured & Threads used between runs
+
+### Discrete
+
 - Process memory usage per Passenger Process PID
 - OS thread count per Passenger Process PID
 - Requests processed per Passenger Process PID
 - Process Idle time per Passenger Process PID
 
 ## Installation
+
 ### Downloading from Github
+
 The `passenger-datadog-monitor` binary can be downloaded from the [releases area](https://github.com/Sjeanpierre/passenger-datadog-monitor/releases) of this repository for Linux
+
 ### Building the binary
+
 You will first need to build the `passenger-datadog-monitor` executable using [Go](https://golang.org). You can download the source and dependencies, and build the binary by running:
-```
+
+```sh
 go get -v github.com/Sjeanpierre/passenger-datadog-monitor
 ```
+
 Once it completes, you should find your new `passenger-datadog-monitor` executable in your `$GOROOT/bin` directory.
 
 Note that if you are building in a different environment from where you plan to deploy, you should configure your [target operating system and architecture](https://golang.org/doc/install/source#environment).
 
 The [Makefile](Makefile) in this repository will cross compile for Linux.
+
 ### Installing the binary
+
 After you've built the executable, you should install it on your server (e.g. in `/usr/bin/`).
 
 ## Usage
+
 `passenger-datadog-monitor` runs as a daemon with a 10 second sampling interval. Monit, God, SupervisorD, or any other daemon management tool should be used to manage the process.
 
 Sample Monit config
 
-```
+```plaintext
 check process passenger-datadog-monitor with pidfile /var/run/passenger-datadog-monitor.pid
 start program = "/etc/init.d/passenger-datadog-monitor start"
 stop  program = "/etc/init.d/passenger-datadog-monitor stop"
@@ -46,6 +61,22 @@ stop  program = "/etc/init.d/passenger-datadog-monitor stop"
 
 You should run `passenger-datadog-monitor` as root, since access to passenger-status requires root.
 
-Running `passenger-datadog-monitor print` will output stats and is useful for debugging.
+### Flags
+
+| flag | type | description | example |
+|:-----|:---|:------------|:---|
+| -host | string | StatsD collector IP - useful when running with a Kubernetes DaemonSet or other external collector | -host=100.124.102.21 |
+| -port | string | StatsD collector UDP Port - useful when running in Docker or other custom environments | -port=81333 |
+| -print | bool | Enable debug and stats printing | -print |
+
+Full example:
+
+```sh
+passenger-datadog-monitor -host=$STATSD_IP -port=$STATSD_PORT
+```
+
+### Testing
 
 [udp.rb](https://github.com/Sjeanpierre/passenger-datadog-monitor/blob/master/server/udp.rb) can be run locally when you want to see what is being received on the server side.
+
+Alternatively you can listen using netcat: `nc -kulvw 0 8125`

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/sjeanpierre/passenger-datadog-monitor
 
 require (
-	github.com/PagerDuty/godspeed v0.0.0-20180224001232-122876cde329
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/theckman/godspeed v1.1.0
+	golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
-github.com/PagerDuty/godspeed v0.0.0-20180224001232-122876cde329 h1:3q+9OIju0tFi+TUZZuG80mRbXI3MT/L/1vlTb8CcofA=
-github.com/PagerDuty/godspeed v0.0.0-20180224001232-122876cde329/go.mod h1:u6OV0JEB9gtT/nTmTNEt6SXkQJW+SBnGWlJoSr+0F+U=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/theckman/godspeed v1.1.0 h1:PJyNf4xeeAMTxf2VFPMBLEEeETTcx804FkIxhd8pkfY=
+github.com/theckman/godspeed v1.1.0/go.mod h1:HbvX1ULDanALaHLD1Q1jwxL3THjMTn6KgpTSZ1MTvMQ=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09 h1:KaQtG+aDELoNmXYas3TVkGNYRuq8JQ1aa7LJt8EXVyo=
+golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/server/udp.rb
+++ b/server/udp.rb
@@ -1,9 +1,13 @@
 require 'socket'
+
 BasicSocket.do_not_reverse_lookup = true
+
 # Create socket and bind to address
 client = UDPSocket.new
-client.bind(nil, 8125)
+client.bind('0.0.0.0', 8125)
+
 loop do
-  data, addr = client.recvfrom(1024) # if this number is too low it will drop the larger packets and never give them to you
+  # if this number is too low it will drop the larger packets and never give them to you
+  data, addr = client.recvfrom(1024)
   puts "From addr: '%s', msg: '%s'" % [addr.join(','), data]
 end


### PR DESCRIPTION
This PR uses `go-flags` to parse simple command line flags, which makes adding new flags easier.  The default host and port stay the same (inherited from `godspeed` package, which has moved) but are now overridable. 

This also uses the golang `net/html/charset` package to handle character encoding instead of the deprecated `go-charset` package.