### PR TITLE
update go.mod with a go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sjeanpierre/passenger-datadog-monitor
 
+go 1.16
+
 require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/theckman/godspeed v1.1.0


### PR DESCRIPTION
Working on updating our docker images to go116 and there is a dependency error which is satisfied by adding a go version in the modules file.

```sh
09:52:40 AM ❯ go get -v github.com/Sjeanpierre/passenger-datadog-monitor
github.com/Sjeanpierre/passenger-datadog-monitor imports
	code.google.com/p/go-charset/charset: cannot find module providing package code.google.com/p/go-charset/charset
github.com/Sjeanpierre/passenger-datadog-monitor imports
	code.google.com/p/go-charset/data: cannot find module providing package code.google.com/p/go-charset/data
zsh: exit 1     go get -v github.com/Sjeanpierre/passenger-datadog-monitor
```